### PR TITLE
Fail when svg is not supported

### DIFF
--- a/slime-volleyball.el
+++ b/slime-volleyball.el
@@ -1714,6 +1714,8 @@
 
 (defun slime-volleyball ()
   (interactive)
+  (unless (image-type-available-p 'svg)
+    (error "Sorry: this Emacs does not support svg images."))
   (setq slime-volleyball-starting t)
   (message "Loading slime strategies...")
   (load-file (expand-file-name "grey-slime.el.gz"


### PR DESCRIPTION
Without this check, the timer functions continue to run (and throw errors) even though the `slime-volleyball` function fails to set up and create the buffer.
